### PR TITLE
fix bitmap crashdump vtype and add 32-bit support

### DIFF
--- a/volatility/plugins/crashinfo.py
+++ b/volatility/plugins/crashinfo.py
@@ -71,7 +71,8 @@ class CrashInfoModification(obj.ProfileModification):
 class CrashInfo(common.AbstractWindowsCommand):
     """Dump crash-dump information"""
 
-    target_as = ['WindowsCrashDumpSpace32', 'WindowsCrashDumpSpace64', 'WindowsCrashDumpSpace64BitMap']
+    target_as = ['WindowsCrashDumpSpace32', 'WindowsCrashDumpSpace64',
+                 'WindowsCrashDumpSpace64BitMap', 'WindowsCrashDumpSpace32BitMap']
 
     @cache.CacheDecorator("tests/crashinfo")
     def calculate(self):


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
